### PR TITLE
chore(mini-css): add cache friendly css output

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -35,8 +35,8 @@ module.exports = {
             filename: "./index.html"
         }),
         new MiniCssExtractPlugin({
-            filename: "[name].scss",
-            chunkFilename: "[id].scss"
+            filename: "[name].[contenthash].scss",
+            chunkFilename: "[id].[contenthash].scss"
         })
     ]
 }


### PR DESCRIPTION
Add [contenthash] instead of hash, for cache purposes.